### PR TITLE
Add LaTeX rendering for expressions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Boolean Expression Comparator</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" />
 </head>
 <body>
   <div id="root"></div>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- render user expressions in LaTeX using KaTeX
- convert parsed tokens to LaTeX via AST helpers
- show rendered expressions below input fields

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d35fb8cc88321a6a3a460ed3d0f76