### PR TITLE
Optimize truth-table evaluation with bit-parallel batch engine

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useRef } from 'react';
 import katex from 'katex';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
-import { allAssignments, astToLatex, compile, evalRPN, type Token } from './booleanExpression';
+import { astToLatex, bitAt, compile, evalRPNBatchBits, type Token } from './booleanExpression';
 
 function asBit(b: boolean): 0 | 1 { return b ? 1 : 0; }
 
@@ -60,20 +60,26 @@ export default function App() {
 
     const valid = compiled.filter((expr): expr is CompiledExpression => expr.error === null);
     const allVars = Array.from(new Set(valid.flatMap((expr) => expr.vars))).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
-    const rows = allAssignments(allVars);
+    const rowCount = Math.max(1, 1 << allVars.length);
 
-    const data = rows.map((env) => {
-      const values = compiled.map((expr) => {
+    const compiledBits = compiled.map((expr) => {
+      if (expr.error || !expr.rpn) return null;
+      const { bits } = evalRPNBatchBits(expr.rpn, allVars);
+      return bits;
+    });
+
+    const data = Array.from({ length: rowCount }, (_, rowIndex) => {
+      const values = compiled.map((expr, exprIdx) => {
         if (expr.error || !expr.rpn) {
           return { id: expr.id, ok: false as const, error: expr.error };
         }
-        return { id: expr.id, ok: true as const, value: evalRPN(expr.rpn, env) };
+        return { id: expr.id, ok: true as const, value: bitAt(compiledBits[exprIdx]!, rowIndex) };
       });
 
       const validValues = values.filter((cell): cell is { id: number; ok: true; value: boolean } => cell.ok).map((cell) => cell.value);
       const hasDiff = validValues.length > 1 && !validValues.every((value) => value === validValues[0]);
 
-      return { env, values, hasDiff };
+      return { rowIndex, values, hasDiff };
     });
 
     return { table: data, vars: allVars, compiledExpressions: compiled };
@@ -231,9 +237,10 @@ export default function App() {
                         transform: `translateY(${item.start - rowVirtualizer.options.scrollMargin}px)`,
                       }}
                     >
-                      {vars.map((v) => (
-                        <div key={v} className="px-3 py-1.5 font-mono">{asBit(row.env[v])}</div>
-                      ))}
+                      {vars.map((v, varIdx) => {
+                        const bit = (row.rowIndex >> (vars.length - 1 - varIdx)) & 1;
+                        return <div key={v} className="px-3 py-1.5 font-mono">{bit as 0 | 1}</div>;
+                      })}
                       {row.values.map((cell) => (
                         <div key={cell.id} className={`px-3 py-1.5 font-mono ${row.hasDiff ? 'text-red-700' : 'text-green-700'}`}>
                           {cell.ok ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useRef } from 'react';
 import katex from 'katex';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
-import { astToLatex, bitAt, compile, evalRPNBatchBits, type Token } from './booleanExpression';
+import { astToLatex, bitAt, compile, evalRPNBatchBits, indicesFromBits, type Token } from './booleanExpression';
 
 function asBit(b: boolean): 0 | 1 { return b ? 1 : 0; }
 
@@ -38,7 +38,7 @@ export default function App() {
   const [nextExprId, setNextExprId] = useState(3);
   const [onlyDiff, setOnlyDiff] = useState(false);
 
-  const { table, vars, compiledExpressions } = useMemo(() => {
+  const { vars, compiledExpressions, compiledBits, rowCount, diffBits } = useMemo(() => {
     const compiled = expressions.map<ExpressionResult>((expr) => {
       if (!expr.value.trim()) {
         return { id: expr.id, value: expr.value, vars: [], rpn: null, latex: '', error: 'Expression is empty' };
@@ -60,36 +60,42 @@ export default function App() {
 
     const valid = compiled.filter((expr): expr is CompiledExpression => expr.error === null);
     const allVars = Array.from(new Set(valid.flatMap((expr) => expr.vars))).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
-    const rowCount = Math.max(1, 1 << allVars.length);
+    const rows = Math.max(1, 1 << allVars.length);
 
-    const compiledBits = compiled.map((expr) => {
+    const bits = compiled.map((expr) => {
       if (expr.error || !expr.rpn) return null;
-      const { bits } = evalRPNBatchBits(expr.rpn, allVars);
-      return bits;
+      return evalRPNBatchBits(expr.rpn, allVars).bits;
     });
 
-    const data = Array.from({ length: rowCount }, (_, rowIndex) => {
-      const values = compiled.map((expr, exprIdx) => {
-        if (expr.error || !expr.rpn) {
-          return { id: expr.id, ok: false as const, error: expr.error };
+    const validBits = bits.filter((b): b is Uint32Array => b !== null);
+    const computedDiffBits = new Uint32Array(Math.ceil(rows / 32));
+    if (validBits.length > 1) {
+      const base = validBits[0];
+      for (let i = 1; i < validBits.length; i++) {
+        const curr = validBits[i];
+        for (let w = 0; w < computedDiffBits.length; w++) {
+          computedDiffBits[w] |= base[w] ^ curr[w];
         }
-        return { id: expr.id, ok: true as const, value: bitAt(compiledBits[exprIdx]!, rowIndex) };
-      });
+      }
+    }
 
-      const validValues = values.filter((cell): cell is { id: number; ok: true; value: boolean } => cell.ok).map((cell) => cell.value);
-      const hasDiff = validValues.length > 1 && !validValues.every((value) => value === validValues[0]);
-
-      return { rowIndex, values, hasDiff };
-    });
-
-    return { table: data, vars: allVars, compiledExpressions: compiled };
+    return {
+      vars: allVars,
+      compiledExpressions: compiled,
+      compiledBits: bits,
+      rowCount: rows,
+      diffBits: computedDiffBits,
+    };
   }, [expressions]);
 
-  const display = useMemo(() => (onlyDiff ? table.filter((r) => r.hasDiff) : table), [table, onlyDiff]);
+  const displayRowIndices = useMemo(
+    () => (onlyDiff ? indicesFromBits(diffBits, rowCount) : Array.from({ length: rowCount }, (_, idx) => idx)),
+    [onlyDiff, diffBits, rowCount]
+  );
 
   const listRef = useRef<HTMLDivElement | null>(null);
   const rowVirtualizer = useWindowVirtualizer({
-    count: display.length,
+    count: displayRowIndices.length,
     estimateSize: () => 35,
     overscan: 5,
     scrollMargin: listRef.current?.offsetTop ?? 0,
@@ -210,7 +216,7 @@ export default function App() {
                 <div key={idx} className="px-3 py-2 font-semibold">Expr {idx + 1}</div>
               ))}
             </div>
-            {display.length === 0 ? (
+            {displayRowIndices.length === 0 ? (
               <div className="px-3 py-4 text-neutral-500">No rows to display.</div>
             ) : (
               <div
@@ -221,8 +227,9 @@ export default function App() {
                 }}
               >
                 {rowVirtualizer.getVirtualItems().map((item) => {
-                  const row = display[item.index];
-                  const rowClass = row.hasDiff ? 'bg-red-50' : 'bg-green-50';
+                  const rowIndex = displayRowIndices[item.index];
+                  const rowHasDiff = bitAt(diffBits, rowIndex);
+                  const rowClass = rowHasDiff ? 'bg-red-50' : 'bg-green-50';
                   return (
                     <div
                       key={item.key}
@@ -238,15 +245,15 @@ export default function App() {
                       }}
                     >
                       {vars.map((v, varIdx) => {
-                        const bit = (row.rowIndex >> (vars.length - 1 - varIdx)) & 1;
+                        const bit = (rowIndex >> (vars.length - 1 - varIdx)) & 1;
                         return <div key={v} className="px-3 py-1.5 font-mono">{bit as 0 | 1}</div>;
                       })}
-                      {row.values.map((cell) => (
-                        <div key={cell.id} className={`px-3 py-1.5 font-mono ${row.hasDiff ? 'text-red-700' : 'text-green-700'}`}>
-                          {cell.ok ? (
-                            asBit(cell.value)
+                      {compiledExpressions.map((expr, exprIdx) => (
+                        <div key={expr.id} className={`px-3 py-1.5 font-mono ${rowHasDiff ? 'text-red-700' : 'text-green-700'}`}>
+                          {expr.error || !expr.rpn ? (
+                            <span title={expr.error} className="text-amber-600">⚠️</span>
                           ) : (
-                            <span title={cell.error} className="text-amber-600">⚠️</span>
+                            asBit(bitAt(compiledBits[exprIdx]!, rowIndex))
                           )}
                         </div>
                       ))}

--- a/src/booleanExpression.performance.test.ts
+++ b/src/booleanExpression.performance.test.ts
@@ -1,6 +1,6 @@
 import { performance } from 'node:perf_hooks';
 import { describe, expect, it } from 'vitest';
-import { allAssignments, compile, evalRPN } from './booleanExpression';
+import { bitAt, compile, evalRPN, evalRPNBatchBits } from './booleanExpression';
 
 type Timing = {
   name: string;
@@ -35,29 +35,49 @@ function measureSingleEvaluation(name: string, expression: string): Timing {
 
 function measureFullTruthTable(name: string, expression: string): Timing {
   const { rpn, vars } = compile(expression);
-  const rows = allAssignments(vars);
+  const rowCount = Math.max(1, 1 << vars.length);
 
-  const start = performance.now();
-  let trueCount = 0;
-  for (const env of rows) {
-    if (evalRPN(rpn, env)) trueCount++;
+  const env: Record<string, boolean> = {};
+  for (const v of vars) env[v] = false;
+
+  const startScalar = performance.now();
+  let trueCountScalar = 0;
+  for (let row = 0; row < rowCount; row++) {
+    for (let i = 0; i < vars.length; i++) {
+      env[vars[i]] = !!((row >> (vars.length - 1 - i)) & 1);
+    }
+    if (evalRPN(rpn, env)) trueCountScalar++;
   }
-  const elapsedMs = performance.now() - start;
+  const scalarMs = performance.now() - startScalar;
+
+  const startBatch = performance.now();
+  const { bits } = evalRPNBatchBits(rpn, vars);
+  let trueCountBatch = 0;
+  for (let row = 0; row < rowCount; row++) {
+    if (bitAt(bits, row)) trueCountBatch++;
+  }
+  const batchMs = performance.now() - startBatch;
 
   console.info('[perf] full-truth-table', {
     name,
     variables: vars.length,
-    evaluations: rows.length,
-    elapsedMs: Number(elapsedMs.toFixed(3)),
-    perEvaluationUs: Number(((elapsedMs * 1000) / rows.length).toFixed(4)),
-    trueCount,
+    evaluations: rowCount,
+    scalarMs: Number(scalarMs.toFixed(3)),
+    batchMs: Number(batchMs.toFixed(3)),
+    speedupX: Number((scalarMs / Math.max(batchMs, 0.0001)).toFixed(2)),
+    trueCountScalar,
+    trueCountBatch,
   });
+
+  if (trueCountScalar !== trueCountBatch) {
+    throw new Error(`Batch and scalar results diverged for ${name}`);
+  }
 
   return {
     name,
     variables: vars.length,
-    evaluations: rows.length,
-    elapsedMs,
+    evaluations: rowCount,
+    elapsedMs: batchMs,
   };
 }
 

--- a/src/booleanExpression.test.ts
+++ b/src/booleanExpression.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { compile, evalRPN } from './booleanExpression';
+import { bitAt, compile, evalRPN, evalRPNBatchBits } from './booleanExpression';
 
 function evaluateExpression(expression: string, env: Record<string, boolean>): boolean {
   return evalRPN(compile(expression).rpn, env);
@@ -54,6 +54,23 @@ describe('boolean expression evaluation regression coverage', () => {
     expect(evaluateExpression('A^B^C^D', { A: true, B: true, C: true, D: false })).toBe(true);
     expect(evaluateExpression('A^B^C^D', { A: true, B: true, C: true, D: true })).toBe(false);
   });
+
+  it('matches scalar and batch evaluation across full truth table', () => {
+    const expression = "((A+B')*(C+!D))^(E*F)+(G'*H)";
+    const { rpn, vars } = compile(expression);
+    const { bits } = evalRPNBatchBits(rpn, vars);
+
+    const rowCount = Math.max(1, 1 << vars.length);
+    const env: Record<string, boolean> = {};
+
+    for (let row = 0; row < rowCount; row++) {
+      for (let i = 0; i < vars.length; i++) {
+        env[vars[i]] = !!((row >> (vars.length - 1 - i)) & 1);
+      }
+      expect(bitAt(bits, row)).toBe(evalRPN(rpn, env));
+    }
+  });
+
 
   it('rejects malformed expressions (without asserting exact error text)', () => {
     expect(() => compile('(A+B')).toThrow();

--- a/src/booleanExpression.ts
+++ b/src/booleanExpression.ts
@@ -274,20 +274,49 @@ export function evalRPN(rpn: Token[], env: Record<string, boolean>): boolean {
   return st[0];
 }
 
-const variableBitsetCache = new Map<string, bigint>();
+const variableBitsetCache = new Map<string, Uint32Array>();
+const allOnesCache = new Map<number, Uint32Array>();
+const allZeroCache = new Map<number, Uint32Array>();
 
-function buildVariableBitset(totalRows: number, varIndex: number, varCount: number): bigint {
+function createAllOnesBits(rows: number): Uint32Array {
+  const cached = allOnesCache.get(rows);
+  if (cached) return cached;
+
+  const words = Math.ceil(rows / 32);
+  const bits = new Uint32Array(words);
+  bits.fill(0xffffffff);
+
+  const remainder = rows & 31;
+  if (remainder !== 0) {
+    bits[words - 1] = (1 << remainder) - 1;
+  }
+
+  allOnesCache.set(rows, bits);
+  return bits;
+}
+
+function createAllZeroBits(rows: number): Uint32Array {
+  const cached = allZeroCache.get(rows);
+  if (cached) return cached;
+
+  const bits = new Uint32Array(Math.ceil(rows / 32));
+  allZeroCache.set(rows, bits);
+  return bits;
+}
+
+function buildVariableBitset(totalRows: number, varIndex: number, varCount: number): Uint32Array {
   const cacheKey = `${varCount}:${varIndex}`;
   const cached = variableBitsetCache.get(cacheKey);
-  if (cached !== undefined) return cached;
+  if (cached) return cached;
 
+  const words = Math.ceil(totalRows / 32);
+  const bits = new Uint32Array(words);
   const period = 1 << (varCount - varIndex);
   const highSpan = period >> 1;
-  let bits = 0n;
 
   for (let row = 0; row < totalRows; row++) {
     if (row % period >= highSpan) {
-      bits |= 1n << BigInt(row);
+      bits[row >> 5] |= 1 << (row & 31);
     }
   }
 
@@ -295,26 +324,51 @@ function buildVariableBitset(totalRows: number, varIndex: number, varCount: numb
   return bits;
 }
 
+function bitwiseBinary(a: Uint32Array, b: Uint32Array, op: 'AND' | 'OR' | 'XOR'): Uint32Array {
+  const out = new Uint32Array(a.length);
+  if (op === 'AND') {
+    for (let i = 0; i < a.length; i++) out[i] = a[i] & b[i];
+  } else if (op === 'OR') {
+    for (let i = 0; i < a.length; i++) out[i] = a[i] | b[i];
+  } else {
+    for (let i = 0; i < a.length; i++) out[i] = a[i] ^ b[i];
+  }
+  return out;
+}
+
+function bitwiseNot(a: Uint32Array, rows: number): Uint32Array {
+  const out = new Uint32Array(a.length);
+  for (let i = 0; i < a.length; i++) out[i] = ~a[i];
+
+  const remainder = rows & 31;
+  if (remainder !== 0) {
+    out[out.length - 1] &= (1 << remainder) - 1;
+  }
+
+  return out;
+}
+
 /**
- * Evaluates an expression for every row of a full truth table in one pass by using bigint bit-parallel operations.
+ * Evaluates an expression for every row of a full truth table in one pass with bit-parallel Uint32 operations.
  * Row ordering matches `allAssignments(vars)`: row 0 is all-zero, row (2^n - 1) is all-one.
  */
-export function evalRPNBatchBits(rpn: Token[], vars: string[]): { bits: bigint; rows: number } {
+export function evalRPNBatchBits(rpn: Token[], vars: string[]): { bits: Uint32Array; rows: number } {
   const varCount = vars.length;
   if (varCount >= 31) {
     throw new Error('Batch evaluation supports at most 30 variables');
   }
 
   const rows = Math.max(1, 1 << varCount);
-  const mask = (1n << BigInt(rows)) - 1n;
   const varIndex = new Map<string, number>();
   for (let i = 0; i < vars.length; i++) varIndex.set(vars[i], i);
 
-  const st: bigint[] = [];
+  const allOnes = createAllOnesBits(rows);
+  const allZero = createAllZeroBits(rows);
+  const st: Uint32Array[] = [];
 
   for (const t of rpn) {
     if (t.type === 'CONST') {
-      st.push(t.value ? mask : 0n);
+      st.push(t.value ? allOnes : allZero);
       continue;
     }
 
@@ -328,14 +382,12 @@ export function evalRPNBatchBits(rpn: Token[], vars: string[]): { bits: bigint; 
     if (t.type === 'OP') {
       if (t.op === 'NOT') {
         if (st.length < 1) throw new Error('NOT missing operand');
-        st.push(mask ^ st.pop()!);
+        st.push(bitwiseNot(st.pop()!, rows));
       } else {
         if (st.length < 2) throw new Error(`${t.op} missing operand`);
         const b = st.pop()!;
         const a = st.pop()!;
-        if (t.op === 'AND') st.push(a & b);
-        else if (t.op === 'OR') st.push(a | b);
-        else st.push(a ^ b);
+        st.push(bitwiseBinary(a, b, t.op));
       }
     }
   }
@@ -344,8 +396,20 @@ export function evalRPNBatchBits(rpn: Token[], vars: string[]): { bits: bigint; 
   return { bits: st[0], rows };
 }
 
-export function bitAt(bits: bigint, row: number): boolean {
-  return ((bits >> BigInt(row)) & 1n) === 1n;
+export function bitAt(bits: Uint32Array, row: number): boolean {
+  return ((bits[row >> 5] >> (row & 31)) & 1) === 1;
+}
+
+function rowsToIndices(bits: Uint32Array, rows: number): number[] {
+  const out: number[] = [];
+  for (let row = 0; row < rows; row++) {
+    if (bitAt(bits, row)) out.push(row);
+  }
+  return out;
+}
+
+export function indicesFromBits(bits: Uint32Array, rows: number): number[] {
+  return rowsToIndices(bits, rows);
 }
 
 export function extractVars(tokens: Token[]): string[] {

--- a/src/booleanExpression.ts
+++ b/src/booleanExpression.ts
@@ -274,6 +274,80 @@ export function evalRPN(rpn: Token[], env: Record<string, boolean>): boolean {
   return st[0];
 }
 
+const variableBitsetCache = new Map<string, bigint>();
+
+function buildVariableBitset(totalRows: number, varIndex: number, varCount: number): bigint {
+  const cacheKey = `${varCount}:${varIndex}`;
+  const cached = variableBitsetCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const period = 1 << (varCount - varIndex);
+  const highSpan = period >> 1;
+  let bits = 0n;
+
+  for (let row = 0; row < totalRows; row++) {
+    if (row % period >= highSpan) {
+      bits |= 1n << BigInt(row);
+    }
+  }
+
+  variableBitsetCache.set(cacheKey, bits);
+  return bits;
+}
+
+/**
+ * Evaluates an expression for every row of a full truth table in one pass by using bigint bit-parallel operations.
+ * Row ordering matches `allAssignments(vars)`: row 0 is all-zero, row (2^n - 1) is all-one.
+ */
+export function evalRPNBatchBits(rpn: Token[], vars: string[]): { bits: bigint; rows: number } {
+  const varCount = vars.length;
+  if (varCount >= 31) {
+    throw new Error('Batch evaluation supports at most 30 variables');
+  }
+
+  const rows = Math.max(1, 1 << varCount);
+  const mask = (1n << BigInt(rows)) - 1n;
+  const varIndex = new Map<string, number>();
+  for (let i = 0; i < vars.length; i++) varIndex.set(vars[i], i);
+
+  const st: bigint[] = [];
+
+  for (const t of rpn) {
+    if (t.type === 'CONST') {
+      st.push(t.value ? mask : 0n);
+      continue;
+    }
+
+    if (t.type === 'VAR') {
+      const idx = varIndex.get(t.name);
+      if (idx === undefined) throw new Error(`Variable '${t.name}' is undefined`);
+      st.push(buildVariableBitset(rows, idx, varCount));
+      continue;
+    }
+
+    if (t.type === 'OP') {
+      if (t.op === 'NOT') {
+        if (st.length < 1) throw new Error('NOT missing operand');
+        st.push(mask ^ st.pop()!);
+      } else {
+        if (st.length < 2) throw new Error(`${t.op} missing operand`);
+        const b = st.pop()!;
+        const a = st.pop()!;
+        if (t.op === 'AND') st.push(a & b);
+        else if (t.op === 'OR') st.push(a | b);
+        else st.push(a ^ b);
+      }
+    }
+  }
+
+  if (st.length !== 1) throw new Error('Invalid expression');
+  return { bits: st[0], rows };
+}
+
+export function bitAt(bits: bigint, row: number): boolean {
+  return ((bits >> BigInt(row)) & 1n) === 1n;
+}
+
 export function extractVars(tokens: Token[]): string[] {
   const set = new Set<string>();
   for (const t of tokens) if (t.type === 'VAR') set.add(t.name);


### PR DESCRIPTION
### Motivation
- Reduce the expensive per-row scalar evaluation performed for full truth-table renders by moving to a bit-parallel model that computes all rows in one pass. 
- Avoid repeated construction of environment objects and repeated per-cell `evalRPN` calls in the app hot path. 
- No external skills were required for this change.

### Description
- Added `evalRPNBatchBits(rpn, vars)` which evaluates an RPN expression across the full truth table using `bigint` bitwise operations and returns a bitset of per-row results. 
- Introduced a reusable `variableBitsetCache` and `buildVariableBitset(...)` to memoize per-variable masks so identical masks are not rebuilt repeatedly. 
- Added `bitAt(bits, row)` helper and a small safeguard limiting batch evaluation to at most 30 variables. 
- Reworked the app pipeline (`src/App.tsx`) to precompute each expression into bitsets and derive row/cell values with `bitAt(...)` and index arithmetic instead of building env objects and calling `evalRPN` per cell. 
- Updated performance tests and unit tests to include scalar-vs-batch comparison and a regression test that asserts exact parity between scalar `evalRPN` and batch `evalRPNBatchBits` across full truth tables.

### Testing
- Ran `npm install` successfully to prepare the environment. 
- Ran the test suite via `npm test -- --run` and all tests passed, including the new scalar-vs-batch equivalence test. 
- Built the project with `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ba0d098083219575cb6e28fa272b)